### PR TITLE
buildconf.mk: Use more standard compiler names and variables

### DIFF
--- a/buildconf.mk
+++ b/buildconf.mk
@@ -49,8 +49,8 @@ CXXFLAGS   := -Wall -g -fPIC -fstack-protector -fstack-protector-all -pthread -W
 INC      := -I. -I$(ROOT_DIR) -I$(BUILD_INCLUDEDIR)
 DEFS     := -D_THREAD_SAFE -D__STDC_FORMAT_MACROS 
 LIBINC   := 
-CC       := gcc
-CPP      := g++
+CC       ?= cc
+CXX      ?= c++
 
 # build setup
 BUILD_DIRS   := $(sort $(BUILD_LIBFSKIT_DIRS) $(BUILD_LIBFSKIT_FUSE_DIRS)) 


### PR DESCRIPTION
- On most distributions, `cc` and `c++` are symlinks to the system's
  C and C++ compilers, which could be GCC, or Clang. The system-wide
  one should be preferred to always using GCC.
- CPP is often used as an abbriviation for the C pre-processor,
  whereas CXX is the usual abbriviation for the C++ compiler.
- In addition, this changes buildconf.mk to allow for having
  $CC and $CXX be used from the environment if they are set already.
  This allows for easier compilation using cross-compilers, which
  are prefixed with the target CHOST.

Examples of $CC and $CXX's usage can be found in build systems such as autoconf.