### PR TITLE
add reference to xaddr.h dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ For libfskit:
 * libpthread
 * librt
 
+And xattr headers:
+* /usr/include/attr/xattr.h
+which in Devuan for instance are packaged as 'libattr1-dev'
+
 For libfskit_fuse:
 * libfskit
 * libfuse (patches alternative backends like 9P and puffs are welcome).


### PR DESCRIPTION
small note in README about the need to have xaddr.h

mostly because the package name is not really obvious in Devuan, doesn't pops up searching for xattr
