### PR TITLE
revert PREFIX to /usr/local, set package specific PREFIX in debian/rules

### DIFF
--- a/buildconf.mk
+++ b/buildconf.mk
@@ -57,7 +57,7 @@ CCFLAGS     := -Wall -std=c11 -g -fPIC -fstack-protector -fstack-protector-all -
 CXXFLAGS   := -Wall -g -fPIC -fstack-protector -fstack-protector-all -pthread -Wno-unused-variable -Wno-unused-but-set-variable
 INC      := -I. -I$(ROOT_DIR) -I$(BUILD_INCLUDEDIR) -I$(BUILD)
 DEFS     := -D_THREAD_SAFE -D__STDC_FORMAT_MACROS $(REPL_DEF)
-LIBINC   := -L. -L$(BUILD_LIBDIR)
+LIBINC   := -L. -L$(BUILD_USRLIB)
 CC       ?= cc
 CXX      ?= c++
 

--- a/buildconf.mk
+++ b/buildconf.mk
@@ -57,7 +57,7 @@ CCFLAGS     := -Wall -std=c11 -g -fPIC -fstack-protector -fstack-protector-all -
 CXXFLAGS   := -Wall -g -fPIC -fstack-protector -fstack-protector-all -pthread -Wno-unused-variable -Wno-unused-but-set-variable
 INC      := -I. -I$(ROOT_DIR) -I$(BUILD_INCLUDEDIR) -I$(BUILD)
 DEFS     := -D_THREAD_SAFE -D__STDC_FORMAT_MACROS $(REPL_DEF)
-LIBINC   := -L. -L$(LIBDIR)
+LIBINC   := -L. -L$(BUILD_LIBDIR)
 CC       ?= cc
 CXX      ?= c++
 

--- a/buildconf.mk
+++ b/buildconf.mk
@@ -16,7 +16,7 @@ BUILD_PRIVATE_INCLUDEDIR := $(BUILD)/fskit_private
 BUILD_ETCDIR := $(BUILD)/etc
 
 # install environment
-DESTDIR        ?= ""
+DESTDIR        ?= 
 PREFIX         ?= /usr/local
 INCLUDE_PREFIX ?= $(PREFIX)
 BINDIR         ?= $(DESTDIR)$(PREFIX)/bin

--- a/buildconf.mk
+++ b/buildconf.mk
@@ -57,7 +57,7 @@ CCFLAGS     := -Wall -std=c11 -g -fPIC -fstack-protector -fstack-protector-all -
 CXXFLAGS   := -Wall -g -fPIC -fstack-protector -fstack-protector-all -pthread -Wno-unused-variable -Wno-unused-but-set-variable
 INC      := -I. -I$(ROOT_DIR) -I$(BUILD_INCLUDEDIR) -I$(BUILD)
 DEFS     := -D_THREAD_SAFE -D__STDC_FORMAT_MACROS $(REPL_DEF)
-LIBINC   := 
+LIBINC   := -L. -L$(LIBDIR)
 CC       ?= cc
 CXX      ?= c++
 

--- a/buildconf.mk
+++ b/buildconf.mk
@@ -16,7 +16,8 @@ BUILD_PRIVATE_INCLUDEDIR := $(BUILD)/fskit_private
 BUILD_ETCDIR := $(BUILD)/etc
 
 # install environment
-PREFIX         ?= /usr
+DESTDIR        ?= ""
+PREFIX         ?= /usr/local
 INCLUDE_PREFIX ?= $(PREFIX)
 BINDIR         ?= $(DESTDIR)$(PREFIX)/bin
 SBINDIR			?= $(DESTDIR)$(PREFIX)/sbin

--- a/debian/control
+++ b/debian/control
@@ -2,15 +2,12 @@ Source: fskit
 Section: libs
 Priority: optional
 Maintainer: Zack Williams, University of Arizona <zdw@cs.arizona.edu>
-Changed-By: Enrico Weigelt, metux IT service <weigelt@metux.de>
 Standards-Version: 3.9.5
 Build-Depends: debhelper (>= 9), libattr1-dev, libfuse-dev, pkg-config
 
 Package: libfskit1
 Architecture: any
-Pre-Depends: ${misc:PreDepends}
-Depends:  ${shlibs:Depends},
-          ${misc:Depends}
+Depends:  ${shlibs:Depends}, ${misc:Depends}
 Description: Helper library for writing synthentic filesystems
  fskit is an SDK for creating filesystems. It provides generic code and data
  structures for managing filesystem inodes, handles, permissions, reference
@@ -21,10 +18,7 @@ Description: Helper library for writing synthentic filesystems
 
 Package: libfskit-fuse1
 Architecture: any
-Pre-Depends: ${misc:PreDepends}
-Depends:  ${shlibs:Depends},
-          ${misc:Depends},
-          libfskit1
+Depends:  ${shlibs:Depends}, ${misc:Depends}, libfskit1 (= ${binary:Version})
 Description: Helper library for writing synthentic filesystems - FUSE backend
  fskit is an SDK for creating filesystems. It provides generic code and data
  structures for managing filesystem inodes, handles, permissions, reference
@@ -35,9 +29,7 @@ Description: Helper library for writing synthentic filesystems - FUSE backend
 Package: libfskit1-dev
 Architecture: any
 Section: libdevel
-Pre-Depends: ${misc:PreDepends}
-Depends:  ${shlibs:Depends},
-          ${misc:Depends}
+Depends: ${misc:Depends}, libfskit1 (= ${binary:Version})
 Description: Helper library for writing synthentic filesystems, dev package
  fskit is an SDK for creating filesystems. It provides generic code and data
  structures for managing filesystem inodes, handles, permissions, reference
@@ -48,10 +40,7 @@ Description: Helper library for writing synthentic filesystems, dev package
 Package: libfskit-fuse1-dev
 Architecture: any
 Section: libdevel
-Pre-Depends: ${misc:PreDepends}
-Depends:  ${shlibs:Depends},
-          ${misc:Depends},
-          libfskit1-dev
+Depends: ${misc:Depends}, libfskit-fuse1 (= ${binary:Version})
 Description: Helper library for writing synthentic filesystems - FUSE backend, dev packag
  fskit is an SDK for creating filesystems. It provides generic code and data
  structures for managing filesystem inodes, handles, permissions, reference

--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,7 @@
 # -*- makefile -*-
 
 export DH_VERBOSE=1
+export PREFIX=/usr
 
 %:
 	dh ${@}

--- a/fuse/Makefile
+++ b/fuse/Makefile
@@ -3,7 +3,7 @@ include ../buildconf.mk
 
 C_SRCS:= $(wildcard *.c)
 OBJ   := $(patsubst %.c,$(BUILD_LIBFSKIT_FUSE)/%.o,$(C_SRCS))
-LIBS  := -lpthread -lfuse -lfskit
+LIBS  := -lpthread -lfuse
 DEFS  := $(DEFS) -D_FILE_OFFSET_BITS=64
 
 PC_FILE		:= $(BUILD_PKGCONFIG)/fskit_fuse.pc
@@ -44,7 +44,7 @@ $(PC_FILE):	$(PC_FILE_IN)
 
 $(LIBFSKIT_FUSE_LIB_TARGET): $(OBJ)
 	@mkdir -p "$(shell dirname "$@")"
-	$(CC) $(CCFLAGS) -shared -Wl,-soname,$(LIBFSKIT_FUSE_SO) -o $(LIBFSKIT_FUSE_LIB_TARGET) $(OBJ) $(LIBINC) $(LIBS)
+	$(CC) $(CCFLAGS) -shared -Wl,-soname,$(LIBFSKIT_FUSE_SO) -o $(LIBFSKIT_FUSE_LIB_TARGET) $(OBJ) $(LIBINC) $(LIBS) -lfskit
 
 $(LIBFSKIT_FUSE_SO_TARGET): $(LIBFSKIT_FUSE_LIB_TARGET)
 	@mkdir -p "$(shell dirname "$@")"

--- a/fuse/Makefile
+++ b/fuse/Makefile
@@ -31,8 +31,8 @@ INSTALL_HEADERS := $(patsubst $(BUILD_LIBFSKIT_FUSE_HEADERS)/%.h,$(INSTALL_LIBFS
 all: $(LIBFSKIT_FUSE_TARGET) $(LIBFSKIT_FUSE_SO_TARGET) $(LIBFSKIT_FUSE_LIB_TARGET) $(BUILD_HEADERS) $(PC_FILE)
 
 $(PC_FILE):	$(PC_FILE_IN)
-	mkdir -p "$(shell dirname "$@")"
-	cat "$<" | \
+	@mkdir -p "$(shell dirname "$@")"
+	@cat "$<" | \
 		sed -e 's~@PREFIX@~$(PREFIX)~g;' | \
 		sed -e 's~@INCLUDEDIR@~$(INCLUDEDIR)~g;' | \
 		sed -e 's~@VERSION@~$(VERSION)~g; ' | \
@@ -43,46 +43,46 @@ $(PC_FILE):	$(PC_FILE_IN)
 	   sed -e 's~@VERSION_PATCH@~$(LIBFSKIT_FUSE_PATCH)~g; '	> "$@"
 
 $(LIBFSKIT_FUSE_LIB_TARGET): $(OBJ)
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	$(CC) $(CCFLAGS) -shared -Wl,-soname,$(LIBFSKIT_FUSE_SO) -o $(LIBFSKIT_FUSE_LIB_TARGET) $(OBJ) $(LIBINC) $(LIBS)
 
 $(LIBFSKIT_FUSE_SO_TARGET): $(LIBFSKIT_FUSE_LIB_TARGET)
-	mkdir -p "$(shell dirname "$@")"
-	ln -sf "$(shell basename "$<")" "$@"
+	@mkdir -p "$(shell dirname "$@")"
+	@ln -sf "$(shell basename "$<")" "$@"
 
 $(LIBFSKIT_FUSE_TARGET): $(LIBFSKIT_FUSE_SO_TARGET)
-	mkdir -p "$(shell dirname "$@")"
-	ln -sf "$(shell basename "$<")" "$@"
+	@mkdir -p "$(shell dirname "$@")"
+	@ln -sf "$(shell basename "$<")" "$@"
 
 $(BUILD_LIBFSKIT_FUSE_HEADERS)/%.h: %.h
-	mkdir -p "$(shell dirname "$@")"
-	cp -a "$<" "$@"
+	@mkdir -p "$(shell dirname "$@")"
+	@cp -a "$<" "$@"
 
 $(BUILD_LIBFSKIT_FUSE)/%.o : %.c $(BUILD_HEADERS)
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	$(CC) $(CCFLAGS) -o "$@" $(INC) -c "$<" $(DEFS)
 
 
 install: $(LIBFSKIT_FUSE_INSTALL_TARGET) $(LIBFSKIT_FUSE_SO_INSTALL_TARGET) $(LIBFSKIT_FUSE_LIB_INSTALL_TARGET) $(PC_FILE_INSTALL) $(INSTALL_HEADERS)
 
 $(LIBFSKIT_FUSE_INSTALL_TARGET): $(LIBFSKIT_FUSE_TARGET)
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(LIBFSKIT_FUSE_SO_INSTALL_TARGET): $(LIBFSKIT_FUSE_SO_TARGET)
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(LIBFSKIT_FUSE_LIB_INSTALL_TARGET): $(LIBFSKIT_FUSE_LIB_TARGET)
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(PC_FILE_INSTALL): $(PC_FILE)
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(INSTALL_LIBFSKIT_FUSE_HEADERS)/%.h: $(BUILD_LIBFSKIT_FUSE_HEADERS)/%.h
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 .PHONY: clean

--- a/fuse/Makefile
+++ b/fuse/Makefile
@@ -3,7 +3,7 @@ include ../buildconf.mk
 
 C_SRCS:= $(wildcard *.c)
 OBJ   := $(patsubst %.c,$(BUILD_LIBFSKIT_FUSE)/%.o,$(C_SRCS))
-LIBS  := -lpthread -lfuse
+LIBS  := -lpthread -lfuse -lfskit
 DEFS  := $(DEFS) -D_FILE_OFFSET_BITS=64
 
 PC_FILE		:= $(BUILD_PKGCONFIG)/fskit_fuse.pc

--- a/fuse/Makefile
+++ b/fuse/Makefile
@@ -3,7 +3,7 @@ include ../buildconf.mk
 
 C_SRCS:= $(wildcard *.c)
 OBJ   := $(patsubst %.c,$(BUILD_LIBFSKIT_FUSE)/%.o,$(C_SRCS))
-LIBS  := -lpthread -lfuse
+LIBS  := -lpthread -lfuse -lfskit
 DEFS  := $(DEFS) -D_FILE_OFFSET_BITS=64
 
 PC_FILE		:= $(BUILD_PKGCONFIG)/fskit_fuse.pc
@@ -31,8 +31,8 @@ INSTALL_HEADERS := $(patsubst $(BUILD_LIBFSKIT_FUSE_HEADERS)/%.h,$(INSTALL_LIBFS
 all: $(LIBFSKIT_FUSE_TARGET) $(LIBFSKIT_FUSE_SO_TARGET) $(LIBFSKIT_FUSE_LIB_TARGET) $(BUILD_HEADERS) $(PC_FILE)
 
 $(PC_FILE):	$(PC_FILE_IN)
-	@mkdir -p "$(shell dirname "$@")"
-	@cat "$<" | \
+	mkdir -p "$(shell dirname "$@")"
+	cat "$<" | \
 		sed -e 's~@PREFIX@~$(PREFIX)~g;' | \
 		sed -e 's~@INCLUDEDIR@~$(INCLUDEDIR)~g;' | \
 		sed -e 's~@VERSION@~$(VERSION)~g; ' | \
@@ -43,46 +43,46 @@ $(PC_FILE):	$(PC_FILE_IN)
 	   sed -e 's~@VERSION_PATCH@~$(LIBFSKIT_FUSE_PATCH)~g; '	> "$@"
 
 $(LIBFSKIT_FUSE_LIB_TARGET): $(OBJ)
-	@mkdir -p "$(shell dirname "$@")"
-	$(CC) $(CCFLAGS) -shared -Wl,-soname,$(LIBFSKIT_FUSE_SO) -o $(LIBFSKIT_FUSE_LIB_TARGET) $(OBJ) $(LIBINC) $(LIBS) -lfskit
+	mkdir -p "$(shell dirname "$@")"
+	$(CC) $(CCFLAGS) -shared -Wl,-soname,$(LIBFSKIT_FUSE_SO) -o $(LIBFSKIT_FUSE_LIB_TARGET) $(OBJ) $(LIBINC) $(LIBS)
 
 $(LIBFSKIT_FUSE_SO_TARGET): $(LIBFSKIT_FUSE_LIB_TARGET)
-	@mkdir -p "$(shell dirname "$@")"
-	@ln -sf "$(shell basename "$<")" "$@"
+	mkdir -p "$(shell dirname "$@")"
+	ln -sf "$(shell basename "$<")" "$@"
 
 $(LIBFSKIT_FUSE_TARGET): $(LIBFSKIT_FUSE_SO_TARGET)
-	@mkdir -p "$(shell dirname "$@")"
-	@ln -sf "$(shell basename "$<")" "$@"
+	mkdir -p "$(shell dirname "$@")"
+	ln -sf "$(shell basename "$<")" "$@"
 
 $(BUILD_LIBFSKIT_FUSE_HEADERS)/%.h: %.h
-	@mkdir -p "$(shell dirname "$@")"
-	@cp -a "$<" "$@"
+	mkdir -p "$(shell dirname "$@")"
+	cp -a "$<" "$@"
 
 $(BUILD_LIBFSKIT_FUSE)/%.o : %.c $(BUILD_HEADERS)
-	@mkdir -p "$(shell dirname "$@")"
+	mkdir -p "$(shell dirname "$@")"
 	$(CC) $(CCFLAGS) -o "$@" $(INC) -c "$<" $(DEFS)
 
 
 install: $(LIBFSKIT_FUSE_INSTALL_TARGET) $(LIBFSKIT_FUSE_SO_INSTALL_TARGET) $(LIBFSKIT_FUSE_LIB_INSTALL_TARGET) $(PC_FILE_INSTALL) $(INSTALL_HEADERS)
 
 $(LIBFSKIT_FUSE_INSTALL_TARGET): $(LIBFSKIT_FUSE_TARGET)
-	@mkdir -p "$(shell dirname "$@")"
+	mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(LIBFSKIT_FUSE_SO_INSTALL_TARGET): $(LIBFSKIT_FUSE_SO_TARGET)
-	@mkdir -p "$(shell dirname "$@")"
+	mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(LIBFSKIT_FUSE_LIB_INSTALL_TARGET): $(LIBFSKIT_FUSE_LIB_TARGET)
-	@mkdir -p "$(shell dirname "$@")"
+	mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(PC_FILE_INSTALL): $(PC_FILE)
-	@mkdir -p "$(shell dirname "$@")"
+	mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(INSTALL_LIBFSKIT_FUSE_HEADERS)/%.h: $(BUILD_LIBFSKIT_FUSE_HEADERS)/%.h
-	@mkdir -p "$(shell dirname "$@")"
+	mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 .PHONY: clean

--- a/libfskit/Makefile
+++ b/libfskit/Makefile
@@ -34,8 +34,8 @@ INSTALL_HEADERS := $(patsubst $(BUILD_LIBFSKIT_HEADERS)/%.h,$(INSTALL_LIBFSKIT_H
 all: $(LIBFSKIT_TARGET) $(LIBFSKIT_SO_TARGET) $(LIBFSKIT_LIB_TARGET) $(BUILD_HEADERS) $(BUILD_PRIVATE_HEADERS) $(PC_FILE)
 
 $(PC_FILE):	$(PC_FILE_IN)
-	mkdir -p "$(shell dirname "$@")"
-	cat "$<" | \
+	@mkdir -p "$(shell dirname "$@")"
+	@cat "$<" | \
 		sed -e 's~@PREFIX@~$(PREFIX)~g;' \
 			 -e 's~@INCLUDEDIR@~$(INCLUDEDIR)~g;' \
 			 -e 's~@VERSION@~$(VERSION)~g; ' \
@@ -46,31 +46,31 @@ $(PC_FILE):	$(PC_FILE_IN)
 			 -e 's~@VERSION_PATCH@~$(LIBFSKIT_PATCH)~g; '	> "$@"
 
 $(LIBFSKIT_LIB_TARGET): $(OBJ)
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	$(CC) $(CCFLAGS) -shared -Wl,-soname,$(LIBFSKIT_SO) -o $(LIBFSKIT_LIB_TARGET) $(OBJ) $(LIBINC) $(LIBS)
 
 $(LIBFSKIT_SO_TARGET): $(LIBFSKIT_LIB_TARGET)
-	mkdir -p "$(shell dirname "$@")"
-	ln -sf "$<" "$@"
+	@mkdir -p "$(shell dirname "$@")"
+	@ln -sf "$(shell basename "$<")" "$@"
 
 $(LIBFSKIT_TARGET): $(LIBFSKIT_SO_TARGET)
-	mkdir -p "$(shell dirname "$@")"
-	ln -sf "$<" "$@"
+	@mkdir -p "$(shell dirname "$@")"
+	@ln -sf "$(shell basename "$<")" "$@"
 
 $(BUILD_PRIVATE_INCLUDEDIR)/%.h: ../include/fskit_private/%.h
-	mkdir -p "$(shell dirname "$@")"
-	cp -a "$<" "$@"
+	@mkdir -p "$(shell dirname "$@")"
+	@cp -a "$<" "$@"
 
 $(BUILD_LIBFSKIT_HEADERS)/%.h: ../include/fskit/%.h
-	mkdir -p "$(shell dirname "$@")"
-	cp -a "$<" "$@"
+	@mkdir -p "$(shell dirname "$@")"
+	@cp -a "$<" "$@"
 
 $(BUILD_LIBFSKIT)/%.o : %.c $(BUILD_HEADERS) $(BUILD_PRIVATE_HEADERS)
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	$(CC) $(CCFLAGS) -o "$@" $(INC) -c "$<" $(DEFS)
 
 $(BUILD_LIBFSKIT)/%.o : %.cpp $(BUILD_HEADERS) $(BUILD_PRIVATE_HEADERS)
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	$(CC) $(CCFLAGS) -o "$@" $(INC) -c "$<" $(DEFS)
 
 libs-install: $(LIBFSKIT_INSTALL_TARGET) $(LIBFSKIT_SO_INSTALL_TARGET) $(LIBFSKIT_LIB_INSTALL_TARGET)
@@ -80,23 +80,23 @@ headers-install: $(PC_FILE_INSTALL) $(INSTALL_HEADERS)
 install: libs-install headers-install
 
 $(LIBFSKIT_INSTALL_TARGET): $(LIBFSKIT_TARGET)
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(LIBFSKIT_SO_INSTALL_TARGET): $(LIBFSKIT_SO_TARGET)
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(LIBFSKIT_LIB_INSTALL_TARGET): $(LIBFSKIT_LIB_TARGET)
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(PC_FILE_INSTALL): $(PC_FILE)
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(INSTALL_LIBFSKIT_HEADERS)/%.h: $(BUILD_LIBFSKIT_HEADERS)/%.h
-	mkdir -p "$(shell dirname "$@")"
+	@mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 .PHONY: clean

--- a/libfskit/Makefile
+++ b/libfskit/Makefile
@@ -34,8 +34,8 @@ INSTALL_HEADERS := $(patsubst $(BUILD_LIBFSKIT_HEADERS)/%.h,$(INSTALL_LIBFSKIT_H
 all: $(LIBFSKIT_TARGET) $(LIBFSKIT_SO_TARGET) $(LIBFSKIT_LIB_TARGET) $(BUILD_HEADERS) $(BUILD_PRIVATE_HEADERS) $(PC_FILE)
 
 $(PC_FILE):	$(PC_FILE_IN)
-	@mkdir -p "$(shell dirname "$@")"
-	@cat "$<" | \
+	mkdir -p "$(shell dirname "$@")"
+	cat "$<" | \
 		sed -e 's~@PREFIX@~$(PREFIX)~g;' \
 			 -e 's~@INCLUDEDIR@~$(INCLUDEDIR)~g;' \
 			 -e 's~@VERSION@~$(VERSION)~g; ' \
@@ -46,31 +46,31 @@ $(PC_FILE):	$(PC_FILE_IN)
 			 -e 's~@VERSION_PATCH@~$(LIBFSKIT_PATCH)~g; '	> "$@"
 
 $(LIBFSKIT_LIB_TARGET): $(OBJ)
-	@mkdir -p "$(shell dirname "$@")"
+	mkdir -p "$(shell dirname "$@")"
 	$(CC) $(CCFLAGS) -shared -Wl,-soname,$(LIBFSKIT_SO) -o $(LIBFSKIT_LIB_TARGET) $(OBJ) $(LIBINC) $(LIBS)
 
 $(LIBFSKIT_SO_TARGET): $(LIBFSKIT_LIB_TARGET)
-	@mkdir -p "$(shell dirname "$@")"
-	@ln -sf "$(shell basename "$<")" "$@"
+	mkdir -p "$(shell dirname "$@")"
+	ln -sf "$(shell basename "$<")" "$@"
 
 $(LIBFSKIT_TARGET): $(LIBFSKIT_SO_TARGET)
-	@mkdir -p "$(shell dirname "$@")"
-	@ln -sf "$(shell basename "$<")" "$@"
+	mkdir -p "$(shell dirname "$@")"
+	ln -sf "$(shell basename "$<")" "$@"
 
 $(BUILD_PRIVATE_INCLUDEDIR)/%.h: ../include/fskit_private/%.h
-	@mkdir -p "$(shell dirname "$@")"
-	@cp -a "$<" "$@"
+	mkdir -p "$(shell dirname "$@")"
+	cp -a "$<" "$@"
 
 $(BUILD_LIBFSKIT_HEADERS)/%.h: ../include/fskit/%.h
-	@mkdir -p "$(shell dirname "$@")"
-	@cp -a "$<" "$@"
+	mkdir -p "$(shell dirname "$@")"
+	cp -a "$<" "$@"
 
 $(BUILD_LIBFSKIT)/%.o : %.c $(BUILD_HEADERS) $(BUILD_PRIVATE_HEADERS)
-	@mkdir -p "$(shell dirname "$@")"
+	mkdir -p "$(shell dirname "$@")"
 	$(CC) $(CCFLAGS) -o "$@" $(INC) -c "$<" $(DEFS)
 
 $(BUILD_LIBFSKIT)/%.o : %.cpp $(BUILD_HEADERS) $(BUILD_PRIVATE_HEADERS)
-	@mkdir -p "$(shell dirname "$@")"
+	mkdir -p "$(shell dirname "$@")"
 	$(CC) $(CCFLAGS) -o "$@" $(INC) -c "$<" $(DEFS)
 
 libs-install: $(LIBFSKIT_INSTALL_TARGET) $(LIBFSKIT_SO_INSTALL_TARGET) $(LIBFSKIT_LIB_INSTALL_TARGET)
@@ -80,23 +80,23 @@ headers-install: $(PC_FILE_INSTALL) $(INSTALL_HEADERS)
 install: libs-install headers-install
 
 $(LIBFSKIT_INSTALL_TARGET): $(LIBFSKIT_TARGET)
-	@mkdir -p "$(shell dirname "$@")"
+	mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(LIBFSKIT_SO_INSTALL_TARGET): $(LIBFSKIT_SO_TARGET)
-	@mkdir -p "$(shell dirname "$@")"
+	mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(LIBFSKIT_LIB_INSTALL_TARGET): $(LIBFSKIT_LIB_TARGET)
-	@mkdir -p "$(shell dirname "$@")"
+	mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(PC_FILE_INSTALL): $(PC_FILE)
-	@mkdir -p "$(shell dirname "$@")"
+	mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 $(INSTALL_LIBFSKIT_HEADERS)/%.h: $(BUILD_LIBFSKIT_HEADERS)/%.h
-	@mkdir -p "$(shell dirname "$@")"
+	mkdir -p "$(shell dirname "$@")"
 	cp -a "$<" "$@"
 
 .PHONY: clean

--- a/libfskit/Makefile
+++ b/libfskit/Makefile
@@ -51,11 +51,11 @@ $(LIBFSKIT_LIB_TARGET): $(OBJ)
 
 $(LIBFSKIT_SO_TARGET): $(LIBFSKIT_LIB_TARGET)
 	mkdir -p "$(shell dirname "$@")"
-	ln -sf "$(shell basename "$<")" "$@"
+	ln -sf "$<" "$@"
 
 $(LIBFSKIT_TARGET): $(LIBFSKIT_SO_TARGET)
 	mkdir -p "$(shell dirname "$@")"
-	ln -sf "$(shell basename "$<")" "$@"
+	ln -sf "$<" "$@"
 
 $(BUILD_PRIVATE_INCLUDEDIR)/%.h: ../include/fskit_private/%.h
 	mkdir -p "$(shell dirname "$@")"


### PR DESCRIPTION
This reverts to previous behavior (builds end up in /usr/local) when compiling standalone, but when building packages, the install into /usr