### PR TITLE
Return listxattr return code

### DIFF
--- a/libfskit/listxattr.c
+++ b/libfskit/listxattr.c
@@ -161,10 +161,9 @@ int fskit_flistxattr( struct fskit_core* core, char const* path, struct fskit_en
    if( rc > 0 ) {
       // callback handled 
       user_size = rc;
+      return user_size;
    }
 
    // not handled
    return fskit_xattr_flistxattr( core, fent, list, size );
 }
-
-


### PR DESCRIPTION
Return `rc` when `fskit_run_user_listxattr` function handled a call. When list vector is null or size is 0, it is a request of length of the name list and it can return `rc > 0`.
